### PR TITLE
Enable AsyncHttpClient to lift Basic Authentication.

### DIFF
--- a/elasticsearch4s/src/main/scala/jp/co/bizreach/elasticsearch4s/HttpUtils.scala
+++ b/elasticsearch4s/src/main/scala/jp/co/bizreach/elasticsearch4s/HttpUtils.scala
@@ -9,6 +9,10 @@ object HttpUtils {
     new AsyncHttpClient()
   }
 
+  def createHttpClient(builder: AsyncHttpClientConfig): AsyncHttpClient = {
+    new AsyncHttpClient(builder)
+  }
+
   def closeHttpClient(httpClient: AsyncHttpClient): Unit = {
     httpClient.close()
   }


### PR DESCRIPTION
ESClientに権限情報を含んだURLを渡した場合は、ベーシック認証を通過するようにESClientを変更。